### PR TITLE
Update README to point to new repo & WP plugin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Easily embed email opt in forms from your ConvertKit.com account.
+**This repo is deprecated. Please see [ConvertKit/ConvertKit-WordPress](https://github.com/ConvertKit/ConvertKit-WordPress) for the new repo, or check the [WordPress plugin repository](https://wordpress.org/plugins/convertkit/).**


### PR DESCRIPTION
I noticed this repo was linked to from [this article](https://convertkit.com/use-convertkit-with-your-wordpress-blog/), so presumably people are still landing here. Let's help them on their way 👌